### PR TITLE
Add neuPrint_graphs.json via LFS

### DIFF
--- a/json_connectomes/.gitattributes
+++ b/json_connectomes/.gitattributes
@@ -1,0 +1,1 @@
+*.json filter=lfs diff=lfs merge=lfs -text

--- a/json_connectomes/neuPrint_graphs.json
+++ b/json_connectomes/neuPrint_graphs.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:865d8ba55e4ee9fc825bc804b12c5781c89113663c7355b4f43f7f9a05ecfc79
+size 667672590


### PR DESCRIPTION
Fix #8 
Add neuPrint_graphs.json via LFS, also file _.gitattributes_ added for using LFS
