### PR TITLE
Fix references in `Affinity_Test`

### DIFF
--- a/docs/Affinity_Testing.ipynb
+++ b/docs/Affinity_Testing.ipynb
@@ -975,7 +975,6 @@
   {
    "source": [
     "```{bibliography}\n",
-    ":style: unsrt\n",
     "```"
    ],
    "cell_type": "markdown",


### PR DESCRIPTION
In `Affinity_Test`, the last cell is supposed to call the references when compiled with Jupyter-Book. However, the formatting of the command is wrong. This is just to fix that so the nb compiles in book